### PR TITLE
disable SRR for nav when on client

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -21,6 +21,7 @@ import { Mutation, useMutation, useQuery } from 'urql';
 import { LogoutDocument, MeDocument } from '../codegen/graphql';
 import { withUrqlClient } from 'next-urql';
 import { createUrqlClient } from '../utils/createUrqlClient';
+import { isServerSide } from '../utils/isServerSide';
 
 const NavLink = ({ children }: { children: ReactNode }) => (
   <Link
@@ -43,6 +44,7 @@ function NavBar() {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [{ data, fetching }] = useQuery({
     query: MeDocument,
+    pause: isServerSide,
   });
 
   const [, logout] = useMutation(LogoutDocument);
@@ -57,7 +59,7 @@ function NavBar() {
 
   if (fetching) {
     body = <div>loading...</div>;
-  } else if (!data.me) {
+  } else if (!data?.me) {
     body = (
       <Link href='/login' style={{ textDecoration: 'none' }}>
         <Button
@@ -137,4 +139,5 @@ function NavBar() {
   );
 }
 
-export default withUrqlClient(createUrqlClient, { ssr: false })(NavBar);
+// export default withUrqlClient(createUrqlClient, { ssr: false })(NavBar);
+export default NavBar;


### PR DESCRIPTION
2 ways to disable SSR, either with a pause prop set to true if "window" is undefined, or what I had before which was explicitly exporting withUrqlClient and passing {SSR: false} to it. 